### PR TITLE
Fix onLayout support in <TextInput> for Android

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -658,7 +658,6 @@ const TextInput = React.createClass({
         onEndEditing={this.props.onEndEditing}
         onSubmitEditing={this.props.onSubmitEditing}
         blurOnSubmit={this.props.blurOnSubmit}
-        onLayout={this.props.onLayout}
         placeholder={this.props.placeholder}
         placeholderTextColor={this.props.placeholderTextColor}
         secureTextEntry={this.props.secureTextEntry}
@@ -676,6 +675,7 @@ const TextInput = React.createClass({
 
     return (
       <TouchableWithoutFeedback
+        onLayout={this.props.onLayout}
         onPress={this._onPress}
         accessible={this.props.accessible}
         accessibilityLabel={this.props.accessibilityLabel}


### PR DESCRIPTION
See #8042: exactly the same bug and fix on Android

**Test plan**

This logs the `nativeEvent` only when the fix is applied:

```jsx
<TextInput onLayout={function(e) { console.log(e.nativeEvent); }} />
```

